### PR TITLE
Replace Apache license with MIT and add headers

### DIFF
--- a/.github/workflows/build-sdv-runtime.yaml
+++ b/.github/workflows/build-sdv-runtime.yaml
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 name: Build Runtime Image
 
 on:

--- a/.github/workflows/release-sdv-runtime.yml
+++ b/.github/workflows/release-sdv-runtime.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 name: Release Docker Image
 
 on:

--- a/.github/workflows/retag-version-as-latest.yml
+++ b/.github/workflows/retag-version-as-latest.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 name: Retag Release Image as Latest
 
 on:

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,56 @@
+# Dependencies and package managers
+node_modules/
+vendor/
+venv/
+.env/
+data/python-packages/
+service/src/app/
+
+# Build outputs
+dist/
+build/
+out/
+target/
+*.min.js
+*.min.css
+
+# Third party code
+third_party/
+external/
+libs/
+
+# Generated files
+*_generated.*
+*.gen.*
+*_pb2.py
+*.pb.go
+
+# Documentation
+*.md
+LICENSE
+NOTICE
+
+# Config files
+.gitignore
+.licenseignore
+package-lock.json
+yarn.lock
+go.sum
+
+# Binary and media files
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.pdf
+*.zip
+*.tar.gz
+
+# Service-specific exclusions (for epam-service-connector)
+service/LICENSE
+service/service.tar.gz
+
+# Third party JavaScript libraries
+public/js/highlight.pack.js

--- a/Kit-Manager/configs.js
+++ b/Kit-Manager/configs.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 const config = {
     port: 3090
 }

--- a/Kit-Manager/src/convert_code.js
+++ b/Kit-Manager/src/convert_code.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 // const fs = require('fs');
 const { ProjectGenerator } = require("./generator/project-generator");
 

--- a/Kit-Manager/src/generator/code-converter.d.ts
+++ b/Kit-Manager/src/generator/code-converter.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { DataPointDefinition } from './utils/helpers';
 export declare class CodeContext {
     appName: string;

--- a/Kit-Manager/src/generator/code-converter.js
+++ b/Kit-Manager/src/generator/code-converter.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/code-converter.js
+++ b/Kit-Manager/src/generator/code-converter.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CodeConverter = exports.CodeContext = void 0;
 const create_code_snippet_1 = require("./pipeline/create-code-snippet");

--- a/Kit-Manager/src/generator/gitRequestHandler.d.ts
+++ b/Kit-Manager/src/generator/gitRequestHandler.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Initialize a new `GitRequestHandler` with the given `options`.
  *

--- a/Kit-Manager/src/generator/gitRequestHandler.js
+++ b/Kit-Manager/src/generator/gitRequestHandler.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2023 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/Kit-Manager/src/generator/gitRequestHandler.js
+++ b/Kit-Manager/src/generator/gitRequestHandler.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/Kit-Manager/src/generator/index.d.ts
+++ b/Kit-Manager/src/generator/index.d.ts
@@ -1,2 +1,10 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export { ProjectGenerator } from './project-generator';
 export { ProjectGeneratorError } from './project-generator-error';

--- a/Kit-Manager/src/generator/index.js
+++ b/Kit-Manager/src/generator/index.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/index.js
+++ b/Kit-Manager/src/generator/index.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ProjectGeneratorError = exports.ProjectGenerator = void 0;
 var project_generator_1 = require("./project-generator");

--- a/Kit-Manager/src/generator/pipeline/create-code-snippet.d.ts
+++ b/Kit-Manager/src/generator/pipeline/create-code-snippet.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/create-code-snippet.js
+++ b/Kit-Manager/src/generator/pipeline/create-code-snippet.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CreateCodeSnippetForTemplateStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/extract-classes.d.ts
+++ b/Kit-Manager/src/generator/pipeline/extract-classes.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/extract-classes.js
+++ b/Kit-Manager/src/generator/pipeline/extract-classes.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ExtractClassesStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/extract-imports.d.ts
+++ b/Kit-Manager/src/generator/pipeline/extract-imports.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/extract-imports.js
+++ b/Kit-Manager/src/generator/pipeline/extract-imports.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ExtractImportsStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/extract-methods.d.ts
+++ b/Kit-Manager/src/generator/pipeline/extract-methods.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/extract-methods.js
+++ b/Kit-Manager/src/generator/pipeline/extract-methods.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ExtractMethodsStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/extract-variables.d.ts
+++ b/Kit-Manager/src/generator/pipeline/extract-variables.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/extract-variables.js
+++ b/Kit-Manager/src/generator/pipeline/extract-variables.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ExtractVariablesStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/pipeline-base.d.ts
+++ b/Kit-Manager/src/generator/pipeline/pipeline-base.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 export interface IPipelineStep {
     execute(context: CodeContext): void;

--- a/Kit-Manager/src/generator/pipeline/pipeline-base.js
+++ b/Kit-Manager/src/generator/pipeline/pipeline-base.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PipelineStep = void 0;

--- a/Kit-Manager/src/generator/pipeline/prepare-code-snippet.d.ts
+++ b/Kit-Manager/src/generator/pipeline/prepare-code-snippet.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { CodeContext } from '../code-converter';
 import { PipelineStep } from './pipeline-base';
 /**

--- a/Kit-Manager/src/generator/pipeline/prepare-code-snippet.js
+++ b/Kit-Manager/src/generator/pipeline/prepare-code-snippet.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.PrepareCodeSnippetStep = void 0;

--- a/Kit-Manager/src/generator/project-generator-error.d.ts
+++ b/Kit-Manager/src/generator/project-generator-error.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 import { AxiosError } from 'axios';
 /**
  * ProjectGeneratorError puts all relevant information together

--- a/Kit-Manager/src/generator/project-generator-error.js
+++ b/Kit-Manager/src/generator/project-generator-error.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/project-generator-error.js
+++ b/Kit-Manager/src/generator/project-generator-error.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ProjectGeneratorError = void 0;
 const axios_1 = require("axios");

--- a/Kit-Manager/src/generator/project-generator.d.ts
+++ b/Kit-Manager/src/generator/project-generator.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 /**
  * Initialize a new `ProjectGenerator` with the given `options`.
  *

--- a/Kit-Manager/src/generator/project-generator.js
+++ b/Kit-Manager/src/generator/project-generator.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/Kit-Manager/src/generator/project-generator.js
+++ b/Kit-Manager/src/generator/project-generator.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/Kit-Manager/src/generator/tests/code-converter.test.d.ts
+++ b/Kit-Manager/src/generator/tests/code-converter.test.d.ts
@@ -1,1 +1,9 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export {};

--- a/Kit-Manager/src/generator/tests/code-converter.test.js
+++ b/Kit-Manager/src/generator/tests/code-converter.test.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {

--- a/Kit-Manager/src/generator/tests/code-converter.test.js
+++ b/Kit-Manager/src/generator/tests/code-converter.test.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);

--- a/Kit-Manager/src/generator/tests/project-generator.test.d.ts
+++ b/Kit-Manager/src/generator/tests/project-generator.test.d.ts
@@ -1,1 +1,9 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export {};

--- a/Kit-Manager/src/generator/tests/project-generator.test.js
+++ b/Kit-Manager/src/generator/tests/project-generator.test.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {

--- a/Kit-Manager/src/generator/tests/project-generator.test.js
+++ b/Kit-Manager/src/generator/tests/project-generator.test.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);

--- a/Kit-Manager/src/generator/tests/regex.test.d.ts
+++ b/Kit-Manager/src/generator/tests/regex.test.d.ts
@@ -1,1 +1,9 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export {};

--- a/Kit-Manager/src/generator/tests/regex.test.js
+++ b/Kit-Manager/src/generator/tests/regex.test.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {

--- a/Kit-Manager/src/generator/tests/regex.test.js
+++ b/Kit-Manager/src/generator/tests/regex.test.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);

--- a/Kit-Manager/src/generator/utils/codeConstants.d.ts
+++ b/Kit-Manager/src/generator/utils/codeConstants.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export declare const PYTHON: {
     CLASS: string;
     IMPORT: string;

--- a/Kit-Manager/src/generator/utils/codeConstants.js
+++ b/Kit-Manager/src/generator/utils/codeConstants.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/utils/codeConstants.js
+++ b/Kit-Manager/src/generator/utils/codeConstants.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.INDENTATION = exports.DIGITAL_AUTO = exports.VELOCITAS = exports.PYTHON = void 0;
 exports.PYTHON = {

--- a/Kit-Manager/src/generator/utils/constants.d.ts
+++ b/Kit-Manager/src/generator/utils/constants.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export declare const GITHUB_API_URL = "https://api.github.com/repos";
 export declare const PYTHON_TEMPLATE_URL: string;
 export declare const CONTENT_ENCODINGS: {

--- a/Kit-Manager/src/generator/utils/constants.js
+++ b/Kit-Manager/src/generator/utils/constants.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/utils/constants.js
+++ b/Kit-Manager/src/generator/utils/constants.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.MAIN_PY_PATH = exports.APP_MANIFEST_PATH = exports.LOCAL_VSPEC_PATH = exports.MS_TO_WAIT_FOR_GITHUB = exports.DEFAULT_COMMIT_MESSAGE = exports.DEFAULT_REPOSITORY_DESCRIPTION = exports.GIT_DATA_MODES = exports.GIT_DATA_TYPES = exports.CONTENT_ENCODINGS = exports.PYTHON_TEMPLATE_URL = exports.GITHUB_API_URL = void 0;
 exports.GITHUB_API_URL = 'https://api.github.com/repos';

--- a/Kit-Manager/src/generator/utils/helpers.d.ts
+++ b/Kit-Manager/src/generator/utils/helpers.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export declare const indentCodeSnippet: (decodedSnippet: string, indentCount: number) => string;
 export declare const createArrayFromMultilineString: (multilineString: string) => string[];
 export declare const createMultilineStringFromArray: (array: string[] | string[][]) => string;

--- a/Kit-Manager/src/generator/utils/helpers.js
+++ b/Kit-Manager/src/generator/utils/helpers.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.encode = exports.decode = exports.delay = exports.insertClassDocString = exports.removeEmptyLines = exports.createMultilineStringFromArray = exports.createArrayFromMultilineString = exports.indentCodeSnippet = void 0;

--- a/Kit-Manager/src/generator/utils/regex.d.ts
+++ b/Kit-Manager/src/generator/utils/regex.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export declare const REGEX: {
     EVERYTHING_BETWEEN_MULTILINE: RegExp;
     GET_EVERY_PLUGINS_USAGE: RegExp;

--- a/Kit-Manager/src/generator/utils/regex.js
+++ b/Kit-Manager/src/generator/utils/regex.js
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-//
-// SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.REGEX = void 0;
 // NOTE: since safari doesn't support lookbehind regex yet. Try to avoid it.

--- a/Kit-Manager/src/generator/utils/regex.js
+++ b/Kit-Manager/src/generator/utils/regex.js
@@ -1,15 +1,11 @@
-"use strict";
-// Copyright (c) 2022 Robert Bosch GmbH
-//
+// Copyright (c) 2025 Eclipse Foundation.
+// 
 // This program and the accompanying materials are made available under the
-// terms of the Apache License, Version 2.0 which is available at
-// https://www.apache.org/licenses/LICENSE-2.0.
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// SPDX-License-Identifier: MIT
+
 //
 // SPDX-License-Identifier: Apache-2.0
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/generator/utils/types.d.ts
+++ b/Kit-Manager/src/generator/utils/types.d.ts
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 export type VspecUriObject = {
     repo: string;
     commit: string;

--- a/Kit-Manager/src/generator/utils/types.js
+++ b/Kit-Manager/src/generator/utils/types.js
@@ -1,2 +1,10 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });

--- a/Kit-Manager/src/index.js
+++ b/Kit-Manager/src/index.js
@@ -1,3 +1,11 @@
+// Copyright (c) 2025 Eclipse Foundation.
+// 
+// This program and the accompanying materials are made available under the
+// terms of the MIT License which is available at
+// https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: MIT
+
 const express = require('express');
 const fs = require('fs');
 const path = require('path');

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025 Eclipse Foundation.
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/kuksa-syncer/main.py
+++ b/kuksa-syncer/main.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 import time
 import asyncio
 import signal

--- a/kuksa-syncer/pkg_manager.py
+++ b/kuksa-syncer/pkg_manager.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import subprocess
 import json

--- a/kuksa-syncer/subpiper/__init__.py
+++ b/kuksa-syncer/subpiper/__init__.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 from .subpiper import subpiper
 
 __all__ = ["subpiper"]

--- a/kuksa-syncer/subpiper/subpiper.py
+++ b/kuksa-syncer/subpiper/subpiper.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Subprocess wrapper for separate, unbuffered capturing / redirecting of stdout and stderr.
 """

--- a/kuksa-syncer/syncer.py
+++ b/kuksa-syncer/syncer.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 import signal
 import subprocess
 from kuksa_client.grpc.aio import VSSClient

--- a/kuksa-syncer/test-gen-vehicle-model.py
+++ b/kuksa-syncer/test-gen-vehicle-model.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 from vehicle_model_manager import generate_vehicle_model, revert_vehicle_model
 # from utils import restartMockProvider
 import time

--- a/kuksa-syncer/utils.py
+++ b/kuksa-syncer/utils.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import signal
 import subprocess

--- a/kuksa-syncer/vehicle_model_manager.py
+++ b/kuksa-syncer/vehicle_model_manager.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import subprocess
 import shutil

--- a/kuksa-syncer/velocitas_app.py
+++ b/kuksa-syncer/velocitas_app.py
@@ -6,9 +6,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-#
-# SPDX-License-Identifier: Apache-2.0
-
 """A sample skeleton vehicle app."""
 
 import asyncio

--- a/kuksa-syncer/velocitas_app.py
+++ b/kuksa-syncer/velocitas_app.py
@@ -1,14 +1,11 @@
-# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
-#
+# Copyright (c) 2025 Eclipse Foundation.
+# 
 # This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# SPDX-License-Identifier: MIT
+
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/mock/lib/action.py
+++ b/mock/lib/action.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/animator.py
+++ b/mock/lib/animator.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 from abc import ABC, abstractmethod

--- a/mock/lib/baseservice.py
+++ b/mock/lib/baseservice.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import asyncio

--- a/mock/lib/behavior.py
+++ b/mock/lib/behavior.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/behaviorexecutor.py
+++ b/mock/lib/behaviorexecutor.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/datapoint.py
+++ b/mock/lib/datapoint.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 from typing import Any, Optional, Callable

--- a/mock/lib/dsl.py
+++ b/mock/lib/dsl.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/loader.py
+++ b/mock/lib/loader.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/mockeddatapoint.py
+++ b/mock/lib/mockeddatapoint.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 from typing import Optional, Callable, Any, List

--- a/mock/lib/trigger.py
+++ b/mock/lib/trigger.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 from abc import ABC, abstractmethod

--- a/mock/lib/types.py
+++ b/mock/lib/types.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 from typing import Any, List, NamedTuple

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 
 from lib.dsl import (
     create_animation_action,

--- a/mock/mockprovider.py
+++ b/mock/mockprovider.py
@@ -1,15 +1,11 @@
-#! /usr/bin/env python3
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import asyncio

--- a/mock/mockservice.py
+++ b/mock/mockservice.py
@@ -1,14 +1,11 @@
-# /********************************************************************************
-# * Copyright (c) 2023 Contributors to the Eclipse Foundation
-# *
-# * See the NOTICE file(s) distributed with this work for additional
-# * information regarding copyright ownership.
-# *
-# * This program and the accompanying materials are made available under the
-# * terms of the Apache License 2.0 which is available at
-# * http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 # ********************************************************************************/
 
 import asyncio

--- a/start_services.sh
+++ b/start_services.sh
@@ -1,3 +1,11 @@
+# Copyright (c) 2025 Eclipse Foundation.
+# 
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+
 #!/bin/sh
 
 DISABLE_DATABROKER=${DISABLE_DATABROKER:-""}


### PR DESCRIPTION
Fixes #13

Replace Apache license with MIT and add headers to address missing license file and header requirements.