### PR TITLE
Revert license headers from MIT to Apache 2.0

### DIFF
--- a/kuksa-syncer/velocitas_app.py
+++ b/kuksa-syncer/velocitas_app.py
@@ -1,10 +1,16 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
 #
-# SPDX-License-Identifier: MIT
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 """A sample skeleton vehicle app."""
 

--- a/mock/lib/action.py
+++ b/mock/lib/action.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/animator.py
+++ b/mock/lib/animator.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 from abc import ABC, abstractmethod

--- a/mock/lib/baseservice.py
+++ b/mock/lib/baseservice.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import asyncio

--- a/mock/lib/behavior.py
+++ b/mock/lib/behavior.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/behaviorexecutor.py
+++ b/mock/lib/behaviorexecutor.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/datapoint.py
+++ b/mock/lib/datapoint.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 from typing import Any, Optional, Callable

--- a/mock/lib/dsl.py
+++ b/mock/lib/dsl.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/loader.py
+++ b/mock/lib/loader.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import logging

--- a/mock/lib/mockeddatapoint.py
+++ b/mock/lib/mockeddatapoint.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 from typing import Optional, Callable, Any, List

--- a/mock/lib/trigger.py
+++ b/mock/lib/trigger.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 from abc import ABC, abstractmethod

--- a/mock/lib/types.py
+++ b/mock/lib/types.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 from typing import Any, List, NamedTuple

--- a/mock/mock.py
+++ b/mock/mock.py
@@ -1,11 +1,3 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
 
 from lib.dsl import (
     create_animation_action,

--- a/mock/mockprovider.py
+++ b/mock/mockprovider.py
@@ -1,11 +1,15 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+#! /usr/bin/env python3
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import asyncio

--- a/mock/mockservice.py
+++ b/mock/mockservice.py
@@ -1,11 +1,14 @@
-# Copyright (c) 2025 Eclipse Foundation.
-# 
-# This program and the accompanying materials are made available under the
-# terms of the MIT License which is available at
-# https://opensource.org/licenses/MIT.
-#
-# SPDX-License-Identifier: MIT
-
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 
 import asyncio


### PR DESCRIPTION
Fixes #56

Revert license headers from MIT to Apache 2.0 for files derived from external sources to maintain proper attribution.